### PR TITLE
Add support for less

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 .gitignore
 .travis.yml
 bower.json
+test/

--- a/dist/tipograf.less
+++ b/dist/tipograf.less
@@ -1,4 +1,11 @@
-@tipograf-base-font-size:  18;
+/**
+ * tipograf - Lightweight pure CSS typography base for your next project
+ * @version v1.0.0
+ * (c) 2016 Tiaan du Plessis @mightyCrow
+ * @link https://github.com/mightyCrow/tipograf
+ * @license MIT
+ */
+ @tipograf-base-font-size:  18;
 @tipograf-base-font-family: medium-content-serif-font, Georgia, Cambria, "Times New Roman", Times, serif;
 @tipograf-base-line-height: 1.5;
 @tipograf-base-font-weight: 400;

--- a/dist/tipograf.less
+++ b/dist/tipograf.less
@@ -1,0 +1,98 @@
+@tipograf-base-font-size:  18;
+@tipograf-base-font-family: medium-content-serif-font, Georgia, Cambria, "Times New Roman", Times, serif;
+@tipograf-base-line-height: 1.5;
+@tipograf-base-font-weight: 400;
+@tipograf-base-letter-spacing: -.004em;
+@tipograf-header-font-family: medium-content-sans-serif-font,"Lucida Grande","Lucida Sans Unicode","Lucida Sans",Geneva,Arial,sans-serif;
+@tipograf-header-font-weight: 700;
+@tipograf-header-scale: 1.67;
+@tipograf-leading-space: @tipograf-base-line-height * 1rem;
+
+html {
+	font-family: @tipograf-base-font-family;
+	font-size: @tipograf-base-font-size / 16 * 100%;
+	font-weight: @tipograf-base-font-weight;
+	font-style: normal;
+	color: rgba(0, 0, 0, 0.8);
+	line-height: @tipograf-base-line-height;
+	font-smoothing: antialiased;
+	text-size-adjust: auto;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	font-family: @tipograf-header-font-family;
+	font-weight: @tipograf-header-font-weight;
+	letter-spacing: @tipograf-base-letter-spacing / 2;
+	margin-bottom: 0;
+}
+
+h1 {
+	font-size: 2.5 * @tipograf-header-scale * 1rem;
+	line-height: 2.3 * @tipograf-leading-space;
+	margin-top: 2 * @tipograf-leading-space;
+}
+
+h2 {
+	font-size: 2.2 * @tipograf-header-scale * 1rem;
+	line-height: 2 * @tipograf-leading-space;
+	margin-top: 1.8 * @tipograf-leading-space;
+}
+
+h3 {
+	font-size: 1.7 * @tipograf-header-scale * 1rem;
+	line-height: 1.5 * @tipograf-leading-space;
+	margin-top: 1.6 * @tipograf-leading-space;
+}
+
+h4 {
+	font-size: 1.5 * @tipograf-header-scale * 1rem;
+	line-height: 1.3 * @tipograf-leading-space;
+	margin-top: 1.4 * @tipograf-leading-space;
+}
+
+h5 {
+	font-size: 1.3 * @tipograf-header-scale * 1rem;
+	line-height: 1.2 * @tipograf-leading-space;
+	margin-top: 1.1 * @tipograf-leading-space;
+}
+
+h6 {
+	font-size: @tipograf-header-scale * 1rem;
+	margin-top: 1.1 * @tipograf-leading-space;
+	line-height: @tipograf-leading-space;
+}
+
+p {
+	letter-spacing: @tipograf-base-letter-spacing;
+	margin-top: @tipograf-leading-space;
+	margin-bottom: 0;
+}
+
+ul, ol {
+	margin-top: @tipograf-leading-space;
+	margin-bottom: @tipograf-leading-space;
+
+	ul, ol {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+
+table {
+	margin-top: @tipograf-leading-space;
+	border-spacing: 0;
+	border-collapse: collapse;
+
+	td, th {
+		padding: 0;
+	}
+}
+
+blockquote {
+	margin-top: @tipograf-leading-space;
+	margin-bottom: @tipograf-leading-space;
+}
+
+code {
+  vertical-align: bottom;
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,8 @@ const del = require('del');
 const $ = gulpLoadPlugins();
 const pkg = require('./package.json');
 const reload = browserSync.reload;
+const less = require('gulp-less');
+
 // Pretty banner
 const banner = ['/**',
     ' * <%= pkg.name %> - <%= pkg.description %>',
@@ -19,7 +21,9 @@ const banner = ['/**',
 // Default paths
 const paths = {
     output: 'dist/',
-    input: `src/**/*.css`
+    input: `src/**/*.css`,
+    less: 'src/**/*.less',
+    testLess: 'test/less/'
 };
 
 // Default postcss plugins
@@ -68,7 +72,18 @@ gulp.task('styles', () => {
         .pipe(gulp.dest(paths.output))
 })
 
-gulp.task('build', ['styles', 'styles:minified'])
+gulp.task('styles:less', () => {
+	return gulp.src(paths.less)
+		.pipe(gulp.dest(paths.output));
+});
+
+gulp.task('test:less', () => {
+	return gulp.src(paths.less)
+		.pipe(less())
+		.pipe(gulp.dest(paths.testLess));
+});
+
+gulp.task('build', ['styles', 'styles:minified', 'styles:less'])
 
 gulp.task('watch', () => {
     gulp.watch(paths.input, ['clean', 'build'])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,9 @@ const paths = {
     output: 'dist/',
     input: `src/**/*.css`,
     less: 'src/**/*.less',
-    testLess: 'test/less/'
+    test: {
+    	less: 'test/less'
+    }
 };
 
 // Default postcss plugins
@@ -80,7 +82,7 @@ gulp.task('styles:less', () => {
 gulp.task('test:less', () => {
 	return gulp.src(paths.less)
 		.pipe(less())
-		.pipe(gulp.dest(paths.testLess));
+		.pipe(gulp.dest(paths.test.less));
 });
 
 gulp.task('build', ['styles', 'styles:minified', 'styles:less'])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,6 +76,9 @@ gulp.task('styles', () => {
 
 gulp.task('styles:less', () => {
 	return gulp.src(paths.less)
+		.pipe($.header(banner, {
+            pkg
+        }))
 		.pipe(gulp.dest(paths.output));
 });
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/tipograf.css",
   "scripts": {
     "test": "echo nope",
+    "test:less": "gulp test:less && opener ./test/less/index.html",
     "build": "gulp build",
     "start": "gulp demo",
     "dev": "gulp",
@@ -28,11 +29,13 @@
     "gh-pages": "^0.11.0",
     "gulp": "^3.9.1",
     "gulp-header": "^1.8.8",
+    "gulp-less": "^3.1.0",
     "gulp-load-plugins": "^1.3.0",
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-size": "^2.1.0",
+    "opener": "^1.4.2",
     "postcss-cssnext": "^2.8.0"
   }
 }

--- a/src/tipograf.less
+++ b/src/tipograf.less
@@ -1,0 +1,98 @@
+@tipograf-base-font-size:  18;
+@tipograf-base-font-family: medium-content-serif-font, Georgia, Cambria, "Times New Roman", Times, serif;
+@tipograf-base-line-height: 1.5;
+@tipograf-base-font-weight: 400;
+@tipograf-base-letter-spacing: -.004em;
+@tipograf-header-font-family: medium-content-sans-serif-font,"Lucida Grande","Lucida Sans Unicode","Lucida Sans",Geneva,Arial,sans-serif;
+@tipograf-header-font-weight: 700;
+@tipograf-header-scale: 1.67;
+@tipograf-leading-space: @tipograf-base-line-height * 1rem;
+
+html {
+	font-family: @tipograf-base-font-family;
+	font-size: @tipograf-base-font-size / 16 * 100%;
+	font-weight: @tipograf-base-font-weight;
+	font-style: normal;
+	color: rgba(0, 0, 0, 0.8);
+	line-height: @tipograf-base-line-height;
+	font-smoothing: antialiased;
+	text-size-adjust: auto;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	font-family: @tipograf-header-font-family;
+	font-weight: @tipograf-header-font-weight;
+	letter-spacing: @tipograf-base-letter-spacing / 2;
+	margin-bottom: 0;
+}
+
+h1 {
+	font-size: 2.5 * @tipograf-header-scale * 1rem;
+	line-height: 2.3 * @tipograf-leading-space;
+	margin-top: 2 * @tipograf-leading-space;
+}
+
+h2 {
+	font-size: 2.2 * @tipograf-header-scale * 1rem;
+	line-height: 2 * @tipograf-leading-space;
+	margin-top: 1.8 * @tipograf-leading-space;
+}
+
+h3 {
+	font-size: 1.7 * @tipograf-header-scale * 1rem;
+	line-height: 1.5 * @tipograf-leading-space;
+	margin-top: 1.6 * @tipograf-leading-space;
+}
+
+h4 {
+	font-size: 1.5 * @tipograf-header-scale * 1rem;
+	line-height: 1.3 * @tipograf-leading-space;
+	margin-top: 1.4 * @tipograf-leading-space;
+}
+
+h5 {
+	font-size: 1.3 * @tipograf-header-scale * 1rem;
+	line-height: 1.2 * @tipograf-leading-space;
+	margin-top: 1.1 * @tipograf-leading-space;
+}
+
+h6 {
+	font-size: @tipograf-header-scale * 1rem;
+	margin-top: 1.1 * @tipograf-leading-space;
+	line-height: @tipograf-leading-space;
+}
+
+p {
+	letter-spacing: @tipograf-base-letter-spacing;
+	margin-top: @tipograf-leading-space;
+	margin-bottom: 0;
+}
+
+ul, ol {
+	margin-top: @tipograf-leading-space;
+	margin-bottom: @tipograf-leading-space;
+
+	ul, ol {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+
+table {
+	margin-top: @tipograf-leading-space;
+	border-spacing: 0;
+	border-collapse: collapse;
+
+	td, th {
+		padding: 0;
+	}
+}
+
+blockquote {
+	margin-top: @tipograf-leading-space;
+	margin-bottom: @tipograf-leading-space;
+}
+
+code {
+  vertical-align: bottom;
+}

--- a/test/less/index.html
+++ b/test/less/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<title>tipograf - Lightweight pure CSS typography base for your next project</title>
+
+	<link rel="stylesheet" href="tipograf.css">
+</head>
+
+<body>
+	<main>
+		<section>
+			<h1>Craft beer</h1>
+			<h2>Craft beer</h2>
+			<h3>Craft beer</h3>
+			<h4>Craft beer</h4>
+			<h5>Craft beer</h5>
+			<h6>Craft beer</h6>
+			<p>Sartorial kale chips street art, coloring book vegan everyday carry polaroid mumblecore snackwave beard. Synth whatever knausgaard, affogato activated charcoal 3 wolf moon hella flannel kombucha +1 copper mug jean shorts gochujang squid. Franzen humblebrag
+				intelligentsia mlkshk knausgaard, typewriter YOLO lyft meggings jean shorts tumblr you probably haven't heard of them bitters. Hoodie typewriter brunch, offal air plant man bun vinyl pork belly authentic coloring book tbh bushwick shoreditch banjo.
+				Mlkshk semiotics subway tile health goth keffiyeh, lyft green juice YOLO iceland sustainable hell of drinking vinegar portland chartreuse. Semiotics cliche skateboard retro, hell of selvage twee health goth yuccie. Ethical kinfolk kitsch narwhal,
+				whatever mumblecore yuccie direct trade copper mug.</p>
+			<p>Craft beer sustainable green juice typewriter sriracha, chartreuse selfies authentic ramps artisan. Skateboard cronut vape, post-ironic meggings letterpress hella celiac raw denim slow-carb lomo hoodie coloring book. Wayfarers fingerstache raw denim
+				kogi occupy pitchfork. Umami helvetica locavore crucifix keytar jianbing. Green juice fingerstache polaroid, venmo 3 wolf moon narwhal keytar tumblr post-ironic fixie meditation franzen kale chips chicharrones vice. Tumblr meditation edison bulb green
+				juice glossier. Scenester flannel man braid, shabby chic chicharrones polaroid fixie squid vaporware lyft vegan edison bulb kinfolk.</p>
+			<h2>Vape artisan hexagon hel</h2>
+			<p>Pug organic lumbersexual, subway tile taxidermy vape sustainable iceland church-key. Fixie cred distillery, church-key aesthetic snackwave intelligentsia ugh. Actually fashion axe pinterest neutra small batch, gentrify synth food truck heirloom keffiyeh.
+				Tbh flannel man braid shabby chic. Helvetica gochujang narwhal fanny pack stumptown. Fingerstache squid street art unicorn, succulents pabst etsy distillery cornhole leggings cray air plant. Disrupt pug swag, hella blog celiac pinterest drinking vinegar
+				try-hard DIY.</p>
+			<h2>Marfa gentrify disrupt wolf</h2>
+			<p>Vape artisan hexagon hell of fap af biodiesel butcher, lo-fi leggings pork belly normcore. Tattooed kale chips fingerstache kogi cronut succulents. Quinoa sustainable sartorial, viral neutra next level artisan ethical street art. Whatever biodiesel
+				keffiyeh, drinking vinegar cliche hexagon pickled iPhone art party franzen succulents direct trade typewriter jianbing. Wayfarers polaroid 90's, sartorial banjo affogato asymmetrical fashion axe selfies. Literally venmo trust fund ethical street art
+				irony, scenester VHS seitan offal vinyl echo park banjo. XOXO hashtag tbh echo park, synth shabby chic freegan gastropub fingerstache tote bag stumptown gentrify deep v brooklyn.</p>
+			<h3>Stumptown tbh food truck</h3>
+			<ul>
+				<li>Photo booth tacos fixie scenester VHS</li>
+				<li>Bitters dreamcatcher poutine wolf microdosing franzen bespoke raw denim</li>
+				<li>Stumptown edison bulb unicorn succulents. Pabst lomo ramps disrupt franzen listicle</li>
+				<li> Church-key twee four dollar toast, scenester lo-fi mlkshk crucifix williamsburg cornhole glossier</li>
+				<li>Food truck skateboard selvage raclette, photo booth lumbersexual four loko quinoa crucifix kickstarter pinterest prism butcher cornhole</li>
+			</ul>
+			<p>Readymade meditation four loko tattooed plaid. Cold-pressed beard coloring book health goth flannel iPhone. Glossier chia four loko lo-fi, knausgaard 8-bit typewriter woke. Leggings kickstarter VHS man bun. Austin edison bulb food truck lyft meh gluten-free.
+				Gentrify everyday carry pork belly unicorn, succulents helvetica small batch blue bottle subway tile bitters vape synth fingerstache fashion axe. Mlkshk 8-bit typewriter dreamcatcher wolf, austin meditation hot chicken waistcoat.</p>
+		</section>
+	</main>
+</body>
+
+</html>

--- a/test/less/tipograf.css
+++ b/test/less/tipograf.css
@@ -1,0 +1,84 @@
+html {
+  font-family: medium-content-serif-font, Georgia, Cambria, "Times New Roman", Times, serif;
+  font-size: 112.5%;
+  font-weight: 400;
+  font-style: normal;
+  color: rgba(0, 0, 0, 0.8);
+  line-height: 1.5;
+  font-smoothing: antialiased;
+  text-size-adjust: auto;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: medium-content-sans-serif-font, "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Geneva, Arial, sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.002em;
+  margin-bottom: 0;
+}
+h1 {
+  font-size: 4.175rem;
+  line-height: 3.45rem;
+  margin-top: 3rem;
+}
+h2 {
+  font-size: 3.674rem;
+  line-height: 3rem;
+  margin-top: 2.7rem;
+}
+h3 {
+  font-size: 2.839rem;
+  line-height: 2.25rem;
+  margin-top: 2.4rem;
+}
+h4 {
+  font-size: 2.505rem;
+  line-height: 1.95rem;
+  margin-top: 2.1rem;
+}
+h5 {
+  font-size: 2.171rem;
+  line-height: 1.8rem;
+  margin-top: 1.65rem;
+}
+h6 {
+  font-size: 1.67rem;
+  margin-top: 1.65rem;
+  line-height: 1.5rem;
+}
+p {
+  letter-spacing: -0.004em;
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+}
+ul,
+ol {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+table {
+  margin-top: 1.5rem;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+table td,
+table th {
+  padding: 0;
+}
+blockquote {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+code {
+  vertical-align: bottom;
+}


### PR DESCRIPTION
Hi!

Saw your post on /r/webdev, really like how minimal this is and would like to use it for a few of my projects. I've added support to expose a tipograf.less so it can be imported by people running less builds and allow for the base variables to be customised.

I couldn't figure out a way to automatically test this so what I've done is added a step to build the less into css and open up the demo webpage with the styles loaded for visual inspection.

`npm run test:less` will do this.

Please let me know if there's anything I've missed and I'll be happy to fix it up. 😄 

Cheers,
Aquib.
